### PR TITLE
allow declarations from consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add `exchange()`, `routing` and `bind` methods to `ConsumerContract`
 
 ## [v1.3.1]
 ### Added

--- a/docs/BASICS.md
+++ b/docs/BASICS.md
@@ -94,6 +94,18 @@ Pigeon::queue('my.awesome.queue')
 Your callback closure can receive a second argument, which is the resolver. The resolver can do the acknowledge and the
 unacknowledged of message with the `ack` and `reject` methods.
 
+Exchanges, routing keys and bindings declarations are possible from the consumer, after the `queue()` method.
+
+```php
+Pigeon::queue($queue)
+    ->exchange($exchange)
+    ->routing($rountingKey)
+    ->bind($queue)
+    ->callback($callback)->consume(0, true);
+```
+
+!> `exchange()` method needs to be called before `rounting()` and `bind()`.
+
 ### Fallback
 The consumer fallback is a closure that is called every time a callback throw a exception.
 It contains 2 arguments, which is the Exception and AMQPMessage instances.

--- a/src/Consumer/Consumer.php
+++ b/src/Consumer/Consumer.php
@@ -15,6 +15,8 @@ class Consumer implements ConsumerContract
     public $fallback;
 
     protected $queue;
+    protected $exchange;
+    protected $routing;
     protected $driver;
     protected $channel;
 
@@ -24,6 +26,28 @@ class Consumer implements ConsumerContract
         $this->queue = $queue;
         $this->driver = $driver;
         $this->channel = $driver->getChannel();
+    }
+
+    public function exchange(string $name, string $type = 'direct'): ConsumerContract
+    {
+        $this->driver->getChannel(2)->exchange_declare($name, $type, false, true, false, false, false, $this->driver->getProps());
+        $this->exchange = $name;
+
+        return $this;
+    }
+
+    public function routing(string $key): ConsumerContract
+    {
+        $this->routing = $key;
+
+        return $this;
+    }
+
+    public function bind(string $queue): ConsumerContract
+    {
+        $this->driver->getChannel(2)->queue_bind($queue, $this->exchange, $this->routing);
+
+        return $this;
     }
 
     public function consume(int $timeout = 0, bool $multiple = true)

--- a/src/Consumer/ConsumerContract.php
+++ b/src/Consumer/ConsumerContract.php
@@ -10,6 +10,12 @@ interface ConsumerContract
 {
     public function __construct(Application $app, DriverContract $driver, string $queue);
 
+    public function exchange(string $name, string $type): self;
+
+    public function routing(string $name): self;
+
+    public function bind(string $queue): self;
+
     public function consume(int $timeout = 5, bool $multiple = true);
 
     public function callback(Closure $callback): self;


### PR DESCRIPTION
Some applications needs to declare their exchanges and bindings from the consumer, this PR adds the required methods to `ConsumerContract` in order to allow declarations from consumer.