### PR TITLE
if method exchange() receive an empty string for exchange name it wil…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added hability to send to default exchange when the exchange name is empty in `exchange()` method
 
 ## [v1.3.1]
 ### Added

--- a/src/Drivers/Driver.php
+++ b/src/Drivers/Driver.php
@@ -45,7 +45,7 @@ abstract class Driver implements DriverContract
 
     public function exchange(string $name, string $type = 'direct'): PublisherContract
     {
-        $this->getChannel(2)->exchange_declare($name, $type, false, true, false, false, false, $this->getProps());
+        $name && $this->getChannel(2)->exchange_declare($name, $type, false, true, false, false, false, $this->getProps());
 
         return new Publisher($this->app, $this, $name);
     }

--- a/src/Drivers/Driver.php
+++ b/src/Drivers/Driver.php
@@ -45,7 +45,7 @@ abstract class Driver implements DriverContract
 
     public function exchange(string $name, string $type = 'direct'): PublisherContract
     {
-        $name && $this->getChannel(2)->exchange_declare($name, $type, false, true, false, false, false, $this->getProps());
+        ($name !== '') && $this->getChannel(2)->exchange_declare($name, $type, false, true, false, false, false, $this->getProps());
 
         return new Publisher($this->app, $this, $name);
     }

--- a/tests/Unit/DriverTest.php
+++ b/tests/Unit/DriverTest.php
@@ -62,6 +62,20 @@ class DriverTest extends TestCase
         $this->assertInstanceOf(PublisherContract::class, $publisher);
     }
 
+    public function test_it_should_use_default_exchange_if_name_not_provided_to_exchange_method()
+    {
+        $type = 'fanout';
+
+        // setup and asserts
+        $this->channel->shouldNotReceive('exchange_declare');
+
+        // act
+        $publisher = $this->driver->exchange('', $type);
+
+        // assert
+        $this->assertInstanceOf(PublisherContract::class, $publisher);
+    }
+
     public function test_it_should_declare_exchange_bind_key()
     {
         $exchange = 'my.exchange';
@@ -135,7 +149,8 @@ class DriverTest extends TestCase
                     && ($app_headers->getNativeData()[$key] === $value)
                     && ($event === $event_name)
                     && ($exchange === Driver::EVENT_EXCHANGE);
-            })->once();
+            }
+        )->once();
         $this->channel->shouldReceive('exchange_declare')->with(
             Driver::EVENT_EXCHANGE,
             Driver::EVENT_EXCHANGE_TYPE,


### PR DESCRIPTION
The `exchange()` method of Driver does not allow messaging to an arbitrary queue through default exchange.

The change provides the hability to pass an empty string to the exchange() method, then the default exchange will be used.