### PR TITLE
Bugfix/capture errors on default fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added hability to test for timeout on consumers
 - Added hability to test for comsmer multiplicit
+### Fixed
+- Catch `Throwble` instead of `Exception` on default fallback
 
 
 ## [v1.4.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added hability to test for comsmer multiplicit
 ### Changed
 - Catch `Throwble` instead of `Exception` on default fallback
+### Fixed
+- Fixed support for Laravel 6
 
 ## [v1.4.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added hability to test for timeout on consumers
 - Added hability to test for comsmer multiplicit
-### Fixed
+### Changed
 - Catch `Throwble` instead of `Exception` on default fallback
 
 ## [v1.4.0]

--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -1,7 +1,7 @@
 ![](./_media/pigeon.svg)
 
 [![Build Status](https://travis-ci.org/convenia/Pigeon.svg?branch=develop)](https://travis-ci.org/convenia/Pigeon)
-[![StyleCI](https://github.styleci.io/repos/201348189/shield?style=develop)](https://github.styleci.io/repos/201348189)
+[![StyleCI](https://github.styleci.io/repos/201348189/shield?style=plastic)](https://github.styleci.io/repos/201348189)
 [![Latest Stable Version](https://poser.pugx.org/convenia/pigeon/v/stable)](https://packagist.org/packages/convenia/pigeon)
 [![Latest Unstable Version](https://poser.pugx.org/convenia/pigeon/v/unstable)](https://packagist.org/packages/convenia/pigeon)
 [![License](https://poser.pugx.org/convenia/pigeon/license)](https://packagist.org/packages/convenia/pigeon)

--- a/src/MessageProcessor/MessageProcessor.php
+++ b/src/MessageProcessor/MessageProcessor.php
@@ -2,12 +2,12 @@
 
 namespace Convenia\Pigeon\MessageProcessor;
 
-use Closure;
 use Convenia\Pigeon\Drivers\DriverContract;
 use Convenia\Pigeon\Resolver\Resolver;
-use Exception;
 use Illuminate\Support\Facades\Log;
 use PhpAmqpLib\Message\AMQPMessage;
+use Throwable;
+use Closure;
 
 class MessageProcessor implements MessageProcessorContract
 {
@@ -26,8 +26,8 @@ class MessageProcessor implements MessageProcessorContract
     {
         try {
             $this->callUserCallback($message);
-        } catch (Exception $e) {
-            $this->callUserFallback($e, $message);
+        } catch (Throwable $t) {
+            $this->callUserFallback($t, $message);
         }
     }
 
@@ -38,22 +38,22 @@ class MessageProcessor implements MessageProcessorContract
         call_user_func($this->callback, $data, new Resolver($message));
     }
 
-    private function callUserFallback(Exception $e, $message)
+    private function callUserFallback(Throwable $t, $message)
     {
         $resolver = new Resolver($message);
         if (! $this->fallback) {
-            return $this->defaultFallback($e, $message, $resolver);
+            return $this->defaultFallback($t, $message, $resolver);
         }
-        call_user_func($this->fallback, $e, $message, $resolver);
+        call_user_func($this->fallback, $t, $message, $resolver);
     }
 
-    private function defaultFallback(Exception $e, $message, $resolver)
+    private function defaultFallback(Throwable $t, $message, $resolver)
     {
-        Log::error($e->getMessage(), [
-            'file'     => $e->getFile(),
-            'line'     => $e->getLine(),
-            'tracing'  => $e->getTraceAsString(),
-            'previous' => $e->getPrevious(),
+        Log::error($t->getMessage(), [
+            'file'     => $t->getFile(),
+            'line'     => $t->getLine(),
+            'tracing'  => $t->getTraceAsString(),
+            'previous' => $t->getPrevious(),
             'message'  => json_decode($message->body, true),
         ]);
 
@@ -65,7 +65,7 @@ class MessageProcessor implements MessageProcessorContract
                 $resolver->reject(false);
                 break;
             default:
-                throw $e;
+                throw $t;
         }
     }
 }


### PR DESCRIPTION
We are catching \Throwable instead of \Exception in MessageProcessor class, this will allow us for catching any kind of Error and Exception.
This PR fixes #111 