### PR TITLE
fix properties on publish method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [v1.6.0]
 ### Fixed
 - Properties on publish method
+## [v1.6.0]
 ### Added
 - Added RPCs test
 - Added support PHPUnit 8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ## [v1.6.0]
+### Fixed
+- Properties on publish method
 ### Added
 - Added RPCs test
 - Added support PHPUnit 8

--- a/src/Publisher/Publisher.php
+++ b/src/Publisher/Publisher.php
@@ -40,7 +40,7 @@ class Publisher implements PublisherContract
 
     public function publish(array $message, array $properties = [], int $channelId = null)
     {
-        $msg = $this->makeMessage($message);
+        $msg = $this->makeMessage($message, $properties);
         $this->driver->getChannel($channelId)->basic_publish(
             $msg,
             $this->exchange,
@@ -78,11 +78,11 @@ class Publisher implements PublisherContract
     private function getMessageProps(array $userProps): array
     {
         return array_merge([
-            'content_type'     => 'application/json',
+            'content_type' => 'application/json',
             'content_encoding' => 'utf8',
-            'correlation_id'   => Uuid::generate()->string,
-            'expiration'       => 60000000,
-            'app_id'           => $this->app['config']['app_name'],
+            'correlation_id' => Uuid::generate()->string,
+            'expiration' => 60000000,
+            'app_id' => $this->app['config']['app_name'],
             'application_headers' => new AMQPTable($this->getHeaders()),
         ], $userProps);
     }

--- a/tests/Unit/PublisherTest.php
+++ b/tests/Unit/PublisherTest.php
@@ -29,7 +29,6 @@ class PublisherTest extends TestCase
     {
         // setup
         $exchange = 'my.awesome.exchange';
-        $routing = 'my.awesome.service';
         $data = [
             'foo' => 'fighters',
         ];
@@ -40,7 +39,13 @@ class PublisherTest extends TestCase
 
         // assert
         $this->channel->shouldReceive('basic_publish')->with(
-            Mockery::type(AMQPMessage::class),
+            Mockery::on(function ($message) {
+                $body = json_decode($message->getBody());
+
+                return 60000000 === $message->get('expiration')
+                    && 10 === $message->get('priority')
+                    && 'fighters' === $body->foo;
+            }),
             $exchange,
             null
         )->once();

--- a/tests/Unit/PublisherTest.php
+++ b/tests/Unit/PublisherTest.php
@@ -25,7 +25,7 @@ class PublisherTest extends TestCase
         $this->driver->shouldReceive('getChannel')->andReturn($this->channel);
     }
 
-    public function test_it_should_publish_message_without_routing_key_with_props()
+    public function test_it_should_publish_message_without_routing_key_and_merge_user_properties_with_default_properties()
     {
         // setup
         $exchange = 'my.awesome.exchange';


### PR DESCRIPTION
This PR allows send properties when publishing messages through publish method, the properties will be appended, the default properties are merged with the new ones. #134 