### PR TITLE
change emmit method name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Catch `Throwble` instead of `Exception` on default fallback
 ### Fixed
 - Fixed support for Laravel 6
-- Fixed facade `emmit` signature
+- Fixed facade `dispatch` signature
 
 ## [v1.4.1]
 ### Removed
@@ -64,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.2.0-beta.1]
 ### Added
-- Add `application_headers` to `Pigeon::emmit` as last parameter
+- Add `application_headers` to `Pigeon::dispatch` as last parameter
 - Add configurable precondition catch on queue creation
 ### Fixed
 - Auto declare exchange with `routing`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Properties on publish method
 ### Added
 - Laravel 8 support
+### Changed
+- Change `emmit` method name to `dispatch`
 ## [v1.6.0]
 ### Added
 - Added RPCs test

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -1,0 +1,11 @@
+# Upgrade Guide
+## From 1.x to 2.x{docsify-ignore}
+ 1. [Laravel 8](#laravel-8)
+ 2. [Change emmit method](#change-emmit-method)
+ 
+## Laravel 8
+If you are considering use Pigeon Version 2.x you does need laravel 8.
+
+## Change emmit method
+Method name `emmit` has changed to `dispatch`, upade all `Pigeon::emmit()` to `Pigeon::dispatch()`
+ 

--- a/src/Drivers/Driver.php
+++ b/src/Drivers/Driver.php
@@ -60,7 +60,7 @@ abstract class Driver implements DriverContract
         return (new Publisher($this->app, $this, $exchange))->routing($name);
     }
 
-    public function emmit(string $eventName, array $event, array $meta = []): void
+    public function dispatch(string $eventName, array $event, array $meta = []): void
     {
         throw_if(empty($event), new EmptyEventException());
         $publisher = $this->exchange(self::EVENT_EXCHANGE, self::EVENT_EXCHANGE_TYPE)->routing($eventName);

--- a/src/Drivers/DriverContract.php
+++ b/src/Drivers/DriverContract.php
@@ -13,7 +13,7 @@ interface DriverContract
 
     public function events(string $event = '*'): ConsumerContract;
 
-    public function emmit(string $eventName, array $event, array $meta = []): void;
+    public function dispatch(string $eventName, array $event, array $meta = []): void;
 
     public function routing(string $name): PublisherContract;
 

--- a/src/Exceptions/Events/EmptyEventException.php
+++ b/src/Exceptions/Events/EmptyEventException.php
@@ -7,7 +7,7 @@ use Throwable;
 
 class EmptyEventException extends Exception
 {
-    public function __construct($message = 'Cannot emmit empty event', $code = 0, Throwable $previous = null)
+    public function __construct($message = 'Cannot dispatch empty event', $code = 0, Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Facade/Pigeon.php
+++ b/src/Facade/Pigeon.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Convenia\Pigeon\Drivers\Driver driver(string $driver)
  * @method static \Convenia\Pigeon\Publisher\PublisherContract routing(string $name = null)
  * @method static \Convenia\Pigeon\Publisher\PublisherContract exchange(string $name, string $type = 'direct')
- * @method static \Convenia\Pigeon\Publisher\PublisherContract emmit(string $eventName, array $event, array $meta = [])
+ * @method static \Convenia\Pigeon\Publisher\PublisherContract dispatch(string $eventName, array $event, array $meta = [])
  * @method static \Convenia\Pigeon\Consumer\ConsumerContract queue(string $name, array $properties = [])
  * @method static \Convenia\Pigeon\Consumer\ConsumerContract events(string $name = '#')
  */

--- a/src/Support/Testing/PigeonFake.php
+++ b/src/Support/Testing/PigeonFake.php
@@ -241,7 +241,7 @@ class PigeonFake extends PigeonManager implements DriverContract
         return $consumer;
     }
 
-    public function emmit(string $eventName, array $event, array $meta = []): void
+    public function dispatch(string $eventName, array $event, array $meta = []): void
     {
         $this->events->push([
             'event' => $eventName,

--- a/tests/Bugs/Bug85.php
+++ b/tests/Bugs/Bug85.php
@@ -44,6 +44,6 @@ class Bug85 extends TestCase
             ->with(3)
             ->andReturn($this->channel);
 
-        $this->driver->emmit('anything', ['foo' => 'bar']);
+        $this->driver->dispatch('anything', ['foo' => 'bar']);
     }
 }

--- a/tests/Integration/Driver/DriverTest.php
+++ b/tests/Integration/Driver/DriverTest.php
@@ -39,7 +39,7 @@ class DriverTest extends TestCase
         $this->channel->queue_bind($this->queue, Driver::EVENT_EXCHANGE, $event_name);
 
         // act
-        $this->driver->emmit($event_name, $event_content);
+        $this->driver->dispatch($event_name, $event_content);
 
         sleep(1);
 
@@ -65,7 +65,7 @@ class DriverTest extends TestCase
         $this->channel->queue_bind($this->queue, Driver::EVENT_EXCHANGE, $event_name);
 
         // act
-        $this->driver->emmit($event_name, $event_content, $meta);
+        $this->driver->dispatch($event_name, $event_content, $meta);
 
         sleep(1);
 

--- a/tests/Integration/Publisher/PublisherTest.php
+++ b/tests/Integration/Publisher/PublisherTest.php
@@ -146,7 +146,7 @@ class PublisherTest extends TestCase
         $this->assertNull($received);
 
         // act
-        $this->pigeon->emmit($event_name, $event_data);
+        $this->pigeon->dispatch($event_name, $event_data);
 
         sleep(1);
         // assert

--- a/tests/Unit/DriverTest.php
+++ b/tests/Unit/DriverTest.php
@@ -125,7 +125,7 @@ class DriverTest extends TestCase
         )->once();
 
         // act
-        $this->driver->emmit($event_name, $event_content);
+        $this->driver->dispatch($event_name, $event_content);
     }
 
     public function test_it_should_publish_event_with_headers()
@@ -163,7 +163,7 @@ class DriverTest extends TestCase
         )->once();
 
         // act
-        $this->driver->emmit($event_name, $event_content, $meta);
+        $this->driver->dispatch($event_name, $event_content, $meta);
     }
 
     public function test_it_should_not_publish_empty_event()
@@ -173,10 +173,10 @@ class DriverTest extends TestCase
         $event_content = [];
 
         // assert
-        $this->expectExceptionMessage('Cannot emmit empty event');
+        $this->expectExceptionMessage('Cannot dispatch empty event');
 
         // act
-        $this->driver->emmit($event_name, $event_content);
+        $this->driver->dispatch($event_name, $event_content);
     }
 
     public function test_it_should_declare_bind_event_queue_and_return_consumer()

--- a/tests/Unit/PigeonFakeTest.php
+++ b/tests/Unit/PigeonFakeTest.php
@@ -392,7 +392,7 @@ class PigeonFakeTest extends TestCase
         } catch (ExpectationFailedException $e) {
             $this->assertThat($e, new ExceptionMessage("No event [$category] emitted with body"));
         }
-        $this->fake->emmit($category, $data);
+        $this->fake->dispatch($category, $data);
 
         $this->fake->assertEmitted($category, $data);
     }


### PR DESCRIPTION
### PROBLEM
`emmit` is misspelled and differ too much from Laravel EventBus Jargon.

### PROPOSAL
change `emmit` to dispatch in order to provide a laravel like jargon.