### PR TITLE
Fix/add laravel back compability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,12 @@ addons:
 matrix:
   fast_finish: true
   include:
+    - php: 7.1
+    - php: 7.1
+      env: SETUP=lowest
+    - php: 7.2
+    - php: 7.2
+      env: SETUP=lowest
     - php: 7.3
     - php: 7.3
       env: SETUP=lowest

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ addons:
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
-    - php: 7.1
-      env: SETUP=lowest
     - php: 7.2
     - php: 7.2
       env: SETUP=lowest

--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
     },
     "require-dev": {
         "ext-curl": "*",
-        "phpunit/phpunit": "7.*|8.*",
+        "phpunit/phpunit": "8.5.*",
         "squizlabs/php_codesniffer": "^2.5",
         "orchestra/testbench": "3.6.*|3.7.*|3.8.*|4.0.*|6.0.*",
-        "mockery/mockery": "1.2.*|1.3.*"
+        "mockery/mockery": "1.2.4|1.3.*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,15 @@
         "ext-json": "*",
         "ext-sockets": "*",
         "php-amqplib/php-amqplib": ">=2.9",
-        "laravel/framework": "^8.0",
+        "laravel/framework": "^5.6|^6.0|^7.0|^8.0",
         "webpatser/laravel-uuid": "^3.0"
     },
     "require-dev": {
         "ext-curl": "*",
         "phpunit/phpunit": "7.*|8.*",
         "squizlabs/php_codesniffer": "^2.5",
-        "orchestra/testbench": "6.0.*",
-        "mockery/mockery": "1.3.*"
+        "orchestra/testbench": "3.6.*|3.7.*|3.8.*|4.0.*|6.0.*",
+        "mockery/mockery": "1.2.*|1.3.*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,12 @@
         {
             "name": "Kauan Sousa",
             "email": "kauanslr.ks@gmail.com",
-            "role": "Original Maintainer"
+            "role": "Maintainer"
+        },
+        {
+            "name": "Leonardo Lemos",
+            "email": "leonardo.lemos@convenia.com.br",
+            "role": "Maintainer"
         }
     ],
     "require": {

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -16,12 +16,6 @@ Pigeon utilizes [Composer](https://getcomposer.org/) to manage its dependencies.
 composer require convenia/pigeon
 ```
 
-?> For Laravel version less than 8 you need to install Pigeon version 1.*
-
-```bash
-composer require convenia/pigeon 1.*
-```
-
 ## Configuring
 Pigeon utilizes laravel auto-discovery feature, so you don't need to setup any service provider or facade.
 After installing Pigeon configure it to connect to your broker.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -8,7 +8,7 @@
  - PHP >= 7.1.3
  - JSON PHP extension
  - Sockets PHP Extension
- 
+
 ## Installing
 Pigeon utilizes [Composer](https://getcomposer.org/) to manage its dependencies. So, before using Laravel, make sure you have Composer installed on your machine.
 

--- a/src/BridgeManager.php
+++ b/src/BridgeManager.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Convenia\Pigeon;
+
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Manager;
+
+/**
+ * Laravel 8 changed app variable doing a BC.
+ * this class holds a reference with the old container name
+ * in order to ensure compatibility with old Laravel versions
+ */
+abstract class BridgeManager extends Manager
+{
+
+    /**
+     * The container instance.
+     *
+     * @var \Illuminate\Contracts\Container\Container
+     */
+    protected $app;
+
+    /**
+     * Create a new manager instance.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return void
+     */
+    public function __construct(Container $container)
+    {
+        $this->app = $container;
+        parent::__construct($container);
+    }
+}

--- a/src/PigeonManager.php
+++ b/src/PigeonManager.php
@@ -5,7 +5,7 @@ namespace Convenia\Pigeon;
 use BadMethodCallException;
 use Convenia\Pigeon\Drivers\RabbitDriver;
 use Convenia\Pigeon\Exceptions\Driver\NullDriverException;
-use Illuminate\Support\Manager;
+use Convenia\Pigeon\BridgeManager as Manager;
 
 /**
  * Class PigeonManager.
@@ -14,13 +14,13 @@ class PigeonManager extends Manager
 {
     public function headers(array $headers)
     {
-        $old = $this->container['config']->get($key = 'pigeon.headers');
-        $this->container['config']->set($key, array_merge($old, $headers));
+        $old = $this->app['config']->get($key = 'pigeon.headers');
+        $this->app['config']->set($key, array_merge($old, $headers));
     }
 
     public function createRabbitDriver()
     {
-        return new RabbitDriver($this->container);
+        return new RabbitDriver($this->app);
     }
 
     public function createNullDriver()
@@ -35,7 +35,7 @@ class PigeonManager extends Manager
      */
     public function getDefaultDriver(): string
     {
-        return $this->container['config']['pigeon.default'] ?? 'null';
+        return $this->app['config']['pigeon.default'] ?? 'null';
     }
 
     /**

--- a/src/Support/Testing/PigeonFake.php
+++ b/src/Support/Testing/PigeonFake.php
@@ -25,9 +25,9 @@ class PigeonFake extends PigeonManager implements DriverContract
 
     public $rpcConsumers;
 
-    public function __construct($container)
+    public function __construct($app)
     {
-        parent::__construct($container);
+        parent::__construct($app);
         $this->consumers = new Collection();
         $this->rpcConsumers = new Collection();
         $this->publishers = new Collection();
@@ -118,7 +118,7 @@ class PigeonFake extends PigeonManager implements DriverContract
     {
         $callback = $callback ?: function ($publisher) use ($routing, $message) {
             return $publisher['routing'] === $routing
-                && $publisher['exchange'] === $this->container['config']['pigeon.exchange']
+                && $publisher['exchange'] === $this->app['config']['pigeon.exchange']
                 && isset($publisher['message'])
                 && $publisher['message'] === $message;
         };
@@ -143,7 +143,7 @@ class PigeonFake extends PigeonManager implements DriverContract
         $callback = $callback ?: function ($publisher) use ($routing, $message) {
             return Str::contains($publisher['routing'], 'rpc.')
                 && $publisher['routing'] === $routing
-                && $publisher['exchange'] === $this->container['config']['pigeon.exchange']
+                && $publisher['exchange'] === $this->app['config']['pigeon.exchange']
                 && isset($publisher['message'])
                 && $publisher['message'] === $message;
         };
@@ -190,8 +190,8 @@ class PigeonFake extends PigeonManager implements DriverContract
         $consumer = $this->consumers->get($queue);
 
         $message->delivery_info['delivery_tag'] = $delivery_tag;
-        $exchange = $this->container['config']['pigeon.exchange'];
-        $publisher = (new Publisher($this->container, $this, $exchange))->routing($reply_to);
+        $exchange = $this->app['config']['pigeon.exchange'];
+        $publisher = (new Publisher($this->app, $this, $exchange))->routing($reply_to);
 
         $this->publishers->push([
             'exchange' => $exchange,
@@ -209,7 +209,7 @@ class PigeonFake extends PigeonManager implements DriverContract
 
     public function queue(string $name): ConsumerContract
     {
-        $consumer = new Consumer($this->container, $this, $name);
+        $consumer = new Consumer($this->app, $this, $name);
         $this->consumers->put($name, $consumer);
 
         return $consumer;
@@ -217,13 +217,13 @@ class PigeonFake extends PigeonManager implements DriverContract
 
     public function exchange(string $name, string $type = 'direct'): PublisherContract
     {
-        return new Publisher($this->container, $this, $name);
+        return new Publisher($this->app, $this, $name);
     }
 
     public function routing(string $name): PublisherContract
     {
-        $exchange = $this->container['config']['pigeon.exchange'];
-        $publisher = (new Publisher($this->container, $this, $exchange))->routing($name);
+        $exchange = $this->app['config']['pigeon.exchange'];
+        $publisher = (new Publisher($this->app, $this, $exchange))->routing($name);
         $this->publishers->push([
             'exchange' => $exchange,
             'routing' => $name,
@@ -235,7 +235,7 @@ class PigeonFake extends PigeonManager implements DriverContract
 
     public function events(string $event = '#'): ConsumerContract
     {
-        $consumer = new Consumer($this->container, $this, $event);
+        $consumer = new Consumer($this->app, $this, $event);
         $this->consumers->put($event, $consumer);
 
         return $consumer;


### PR DESCRIPTION
### Add back compability

Lets release a version 1.7 with L8 support without a single BC instead of release a 2.0 supporting only L8.
dev-master will contain BC and WIP code, lets tag 1.7 and forward in 1.x branch