### PR TITLE
Php8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .phpunit.result.cache
 vendor/
+coverage/
 composer.lock
 phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ matrix:
     - php: 7.4
     - php: 7.4
       env: SETUP=lowest
+    - php: 8.0
+    - php: 8.0
+      env: SETUP=lowest
 
 cache:
   directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Laravel 8 support
 ### Changed
 - Change `emmit` method name to `dispatch`
+- Change `assertEmitted` method name to `assertDispatched`
 ## [v1.6.0]
 ### Added
 - Added RPCs test

--- a/composer.json
+++ b/composer.json
@@ -16,17 +16,11 @@
             "role": "Maintainer"
         }
     ],
-    "repositories": [
-        {
-            "type": "git",
-            "url": "git@github.com:jleonardolemos/php-amqplib.git"
-        }
-    ],
     "require": {
         "php": ">=7.1.3",
         "ext-json": "*",
         "ext-sockets": "*",
-        "php-amqplib/php-amqplib": "dev-php8_fixes",
+        "php-amqplib/php-amqplib": "^3.0",
         "laravel/framework": "^5.6|^6.0|^7.0|^8.0",
         "webpatser/laravel-uuid": "^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,19 @@
             "role": "Maintainer"
         }
     ],
+    "repositories": [
+        {
+            "type": "git",
+            "url": "git@github.com:jleonardolemos/php-amqplib.git"
+        }
+    ],
     "require": {
         "php": ">=7.1.3",
         "ext-json": "*",
         "ext-sockets": "*",
-        "php-amqplib/php-amqplib": ">=2.9",
+        "php-amqplib/php-amqplib": "dev-php8_fixes",
         "laravel/framework": "^5.6|^6.0|^7.0|^8.0",
-        "webpatser/laravel-uuid": "^3.0"
+        "webpatser/laravel-uuid": "^4.0"
     },
     "require-dev": {
         "ext-curl": "*",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "ext-curl": "*",
-        "phpunit/phpunit": "8.5.*",
+        "phpunit/phpunit": ">=8.5",
         "squizlabs/php_codesniffer": "^2.5",
         "orchestra/testbench": "3.6.*|3.7.*|3.8.*|4.0.*|6.0.*",
         "mockery/mockery": "1.2.4|1.3.*"

--- a/docs/EVENT_DRIVEN.md
+++ b/docs/EVENT_DRIVEN.md
@@ -3,10 +3,10 @@
 
 ## Dispatching Events
 
-Very similar to `publish` method, Pigeon has an `emmit` method.
+Very similar to `publish` method, Pigeon has an `dispatch` method.
 
 ```PHP
-Pigeon::emmit('payment.purchase.done', [
+Pigeon::dispatch('payment.purchase.done', [
     'uuid' => $user->uuid,
     'value' => 1000
     'status' => 'Done'
@@ -22,7 +22,7 @@ Now we are emitting the `payment.purchase.done` event, by convention we use dot 
 2. The second parameter is the body message, this must be the main content.
 3. The third param are the headers, it lives in `application_headers` property from message.
 
-By the book, when you use publish method, you know the consumer, you send directally to the consumer(only one consumer), emmit method is different, you don't know the consumer and actually it can have more than one consumer, it's a event/subiscriber architecture.
+By the book, when you use publish method, you know the consumer, you send directally to the consumer(only one consumer), dispatch method is different, you don't know the consumer and actually it can have more than one consumer, it's a event/subiscriber architecture.
 
 ### How it works behind the scenes?
 
@@ -32,7 +32,7 @@ If you are not acquainted with routing, see [rabbitmq docs](https://www.rabbitmq
 
 ## Listening For Events
 
-The previous section have introduced the `emmit` method, but this method will send the event to an exchange without a binded queue, the emitter is talking but no one is listening... our shipping service should listen for orders from payment service, lets do this.
+The previous section have introduced the `dispatch` method, but this method will send the event to an exchange without a binded queue, the emitter is talking but no one is listening... our shipping service should listen for orders from payment service, lets do this.
 
 ```PHP
 Pigeon::events('payment.purchase.done')
@@ -44,9 +44,9 @@ Pigeon::events('payment.purchase.done')
 
 Just put this code in an artisan command and we are ready to go...
 
-The method `events` will listen for events named with his param, the param should be identical to the event name used on emmit method.
+The method `events` will listen for events named with his param, the param should be identical to the event name used on dispatch method.
 
-The callback method defines a handler to the event, the first param is the message body sent by `emmit` method, the second param is the resolver.
+The callback method defines a handler to the event, the first param is the message body sent by `dispatch` method, the second param is the resolver.
 
 !> Its very important to call `$resolver->ack();` when all goes well, if you dont, the message will never get out of the queue and the listener will process the message for ever
 

--- a/phpunit-ci.xml
+++ b/phpunit-ci.xml
@@ -1,43 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         verbose="true"
->
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/Unit</directory>
-        </testsuite>
-        <testsuite name="Integration">
-            <directory suffix="Test.php">./tests/Integration</directory>
-        </testsuite>
-        <testsuite name="Bugs">
-            <directory prefix="Bug" suffix=".php">./tests/Bugs</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="false">
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-
-    <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
-        <env name="PIGEON_DRIVER" value="rabbit"/>
-        <env name="PIGEON_ADDRESS" value="localhost"/>
-        <env name="PIGEON_PORT" value="5672"/>
-        <env name="PIGEON_USER" value="guest"/>
-        <env name="PIGEON_PASSWORD" value="guest"/>
-        <env name="PIGEON_VHOST" value="/"/>
-        <env name="PIGEON_KEEPALIVE" value="true"/>
-        <env name="PIGEON_HEARTBEAT" value="60"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" verbose="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="false">
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/Unit</directory>
+    </testsuite>
+    <testsuite name="Integration">
+      <directory suffix="Test.php">./tests/Integration</directory>
+    </testsuite>
+    <testsuite name="Bugs">
+      <directory prefix="Bug" suffix=".php">./tests/Bugs</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+    <env name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
+    <env name="PIGEON_DRIVER" value="rabbit"/>
+    <env name="PIGEON_ADDRESS" value="localhost"/>
+    <env name="PIGEON_PORT" value="5672"/>
+    <env name="PIGEON_USER" value="guest"/>
+    <env name="PIGEON_PASSWORD" value="guest"/>
+    <env name="PIGEON_VHOST" value="/"/>
+    <env name="PIGEON_KEEPALIVE" value="true"/>
+    <env name="PIGEON_HEARTBEAT" value="60"/>
+  </php>
 </phpunit>

--- a/phpunit-ci.xml
+++ b/phpunit-ci.xml
@@ -16,6 +16,11 @@
       <directory prefix="Bug" suffix=".php">./tests/Bugs</directory>
     </testsuite>
   </testsuites>
+  <filter>
+      <whitelist addUncoveredFilesFromWhitelist="false">
+          <directory suffix=".php">src/</directory>
+      </whitelist>
+  </filter>
   <php>
     <env name="APP_ENV" value="testing"/>
     <env name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,43 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         verbose="true"
->
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/Unit</directory>
-        </testsuite>
-        <testsuite name="Integration">
-            <directory suffix="Test.php">./tests/Integration</directory>
-        </testsuite>
-        <testsuite name="Bugs">
-            <directory prefix="Bug" suffix=".php">./tests/Bugs</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="false">
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-
-    <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
-        <env name="PIGEON_DRIVER" value="rabbit"/>
-        <env name="PIGEON_ADDRESS" value="localhost"/>
-        <env name="PIGEON_PORT" value="5672"/>
-        <env name="PIGEON_USER" value="guest"/>
-        <env name="PIGEON_PASSWORD" value="guest"/>
-        <env name="PIGEON_VHOST" value="/"/>
-        <env name="PIGEON_KEEPALIVE" value="true"/>
-        <env name="PIGEON_HEARTBEAT" value="60"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" verbose="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="false">
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/Unit</directory>
+    </testsuite>
+    <testsuite name="Integration">
+      <directory suffix="Test.php">./tests/Integration</directory>
+    </testsuite>
+    <testsuite name="Bugs">
+      <directory prefix="Bug" suffix=".php">./tests/Bugs</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+    <env name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
+    <env name="PIGEON_DRIVER" value="rabbit"/>
+    <env name="PIGEON_ADDRESS" value="localhost"/>
+    <env name="PIGEON_PORT" value="5672"/>
+    <env name="PIGEON_USER" value="guest"/>
+    <env name="PIGEON_PASSWORD" value="guest"/>
+    <env name="PIGEON_VHOST" value="/"/>
+    <env name="PIGEON_KEEPALIVE" value="true"/>
+    <env name="PIGEON_HEARTBEAT" value="60"/>
+  </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,6 +16,11 @@
       <directory prefix="Bug" suffix=".php">./tests/Bugs</directory>
     </testsuite>
   </testsuites>
+  <filter>
+      <whitelist addUncoveredFilesFromWhitelist="false">
+          <directory suffix=".php">src/</directory>
+      </whitelist>
+  </filter>
   <php>
     <env name="APP_ENV" value="testing"/>
     <env name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>

--- a/src/Support/Testing/PigeonFake.php
+++ b/src/Support/Testing/PigeonFake.php
@@ -106,7 +106,7 @@ class PigeonFake extends PigeonManager implements DriverContract
         );
     }
 
-    public function assertEmitted(string $category, array $data)
+    public function assertDispatched(string $category, array $data)
     {
         PHPUnit::assertTrue(
             $this->emitted($category, $data),

--- a/tests/Unit/ConsumerTest.php
+++ b/tests/Unit/ConsumerTest.php
@@ -81,7 +81,7 @@ class ConsumerTest extends TestCase
 
         $consumer->consume(5, true);
 
-        $this->assertTrue($times == 2, 'Called two times');
+        $this->assertTrue($times === 2, 'Called two times');
     }
 
     public function test_it_should_return_a_message_processor()

--- a/tests/Unit/PigeonFakeTest.php
+++ b/tests/Unit/PigeonFakeTest.php
@@ -518,7 +518,6 @@ class PigeonFakeTest extends TestCase
         $this->fake
         ->queue($queue)
         ->callback(function ($event, ResolverContract $resolver) use (&$run) {
-            $event;
             $resolver->ack();
             $run = true;
         })->consume();

--- a/tests/Unit/PigeonFakeTest.php
+++ b/tests/Unit/PigeonFakeTest.php
@@ -387,14 +387,14 @@ class PigeonFakeTest extends TestCase
 
         // act
         try {
-            $this->fake->assertEmitted($category, $data);
+            $this->fake->assertDispatched($category, $data);
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertThat($e, new ExceptionMessage("No event [$category] emitted with body"));
         }
         $this->fake->dispatch($category, $data);
 
-        $this->fake->assertEmitted($category, $data);
+        $this->fake->assertDispatched($category, $data);
     }
 
     public function test_it_should_assert_consuming_event()

--- a/tests/Unit/PigeonManagerTest.php
+++ b/tests/Unit/PigeonManagerTest.php
@@ -2,9 +2,12 @@
 
 namespace Convenia\Pigeon\Tests\Unit;
 
+use BadMethodCallException;
+use Convenia\Pigeon\Drivers\RabbitDriver;
 use Convenia\Pigeon\Exceptions\Driver\NullDriverException;
 use Convenia\Pigeon\PigeonManager;
 use Convenia\Pigeon\Tests\TestCase;
+use Mockery;
 
 class PigeonManagerTest extends TestCase
 {
@@ -76,5 +79,33 @@ class PigeonManagerTest extends TestCase
             'foo' => 'fighters',
         ]);
         $this->assertEquals($headers, $this->app['config']->get('pigeon.headers'));
+    }
+
+    public function test_it_should_delegate_calls_to_driver()
+    {
+        $driver = Mockery::mock(RabbitDriver::class);
+        $driver->shouldReceive('getChannel')
+            ->once()
+            ->with(28);
+
+        $manager = Mockery::mock(PigeonManager::class)->makePartial();
+        $manager->shouldReceive('driver')
+            ->twice()
+            ->andReturn($driver);
+
+        $manager->getChannel(28);
+
+        $this->assertFalse(
+            method_exists($manager, 'getChannel')
+        );
+    }
+
+    public function test_it_should_throw_exception_delegating_unimplemented_method()
+    {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('Call to undefined method Convenia\Pigeon\PigeonManager::unimplementedMethod()');
+
+        $manager = new PigeonManager($this->app);
+        $manager->unimplementedMethod();
     }
 }


### PR DESCRIPTION
## Proposal
Support php8, the 2.0 Pigeon release will be launched after support for php8 is fine.
We are using a fork from axxapy user [https://github.com/axxapy/php-amqplib/tree/php8_fixes](https://github.com/axxapy/php-amqplib/tree/php8_fixes) to provide full compatibility with php8 but we will only merge this branch after amqpplib support php8 [https://github.com/php-amqplib/php-amqplib/pull/858](https://github.com/php-amqplib/php-amqplib/pull/858).

## Concerns
1. The php8 can be supported only in amqplib version 3, that should bring some breaking changes from amqplib too, `->delivery_info` is a great concert because it is deprecated.
2. Pigeon codebase is not 100% covered, then we can see this MR as safe only after testing in a real application.