### PR TITLE
Creation of a Developer Environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM php:7.4-fpm-alpine
+
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+RUN apk --no-cache --update add libmemcached-dev zlib-dev libpng-dev libjpeg-turbo-dev freetype-dev libxml2-dev
+
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
+&& docker-php-ext-install -j$(nproc) gd sockets fileinfo dom tokenizer xml simplexml
+
+RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 RUN apk --no-cache --update add libmemcached-dev zlib-dev libpng-dev libjpeg-turbo-dev freetype-dev libxml2-dev
 
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
-&& docker-php-ext-install -j$(nproc) gd sockets fileinfo dom tokenizer xml simplexml
+&& docker-php-ext-install -j$(nproc) gd sockets fileinfo dom tokenizer xml simplexml pcntl
 
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM php:7.4-fpm-alpine
+FROM php:8.1-fpm-alpine
 
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 RUN apk --no-cache --update add libmemcached-dev zlib-dev libpng-dev libjpeg-turbo-dev freetype-dev libxml2-dev
 
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
-&& docker-php-ext-install -j$(nproc) gd sockets fileinfo dom tokenizer xml simplexml pcntl
+&& docker-php-ext-install -j$(nproc) gd sockets fileinfo dom xml simplexml pcntl
 
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
   rabbitmq:
     container_name: rabbitmq
-    image: rabbitmq
+    image: rabbitmq:3.8
     hostname: rabbitmq
     networks:
       pigeon-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.3'
+services:
+  pigeon:
+    container_name: pigeon
+    build: .
+    working_dir: /var/www/Pigeon
+    volumes:
+      - .:/var/www/Pigeon
+    networks:
+      pigeon-network:
+        ipv4_address: 172.40.10.30
+        aliases:
+          - rabbitmq
+
+  rabbitmq:
+    container_name: rabbitmq
+    image: rabbitmq
+    hostname: rabbitmq
+    networks:
+      pigeon-network:
+        ipv4_address: 172.40.10.20
+        aliases:
+          - rabbitmq
+
+networks:
+  pigeon-network:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.40.10.0/24

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,9 @@ services:
   pigeon:
     container_name: pigeon
     build: .
-    working_dir: /var/www/Pigeon
+    working_dir: /var/www/package
     volumes:
-      - .:/var/www/Pigeon
+      - .:/var/www/package
     networks:
       pigeon-network:
         ipv4_address: 172.40.10.30

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,7 +20,7 @@
     <env name="APP_ENV" value="testing"/>
     <env name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
     <env name="PIGEON_DRIVER" value="rabbit"/>
-    <env name="PIGEON_ADDRESS" value="localhost"/>
+    <env name="PIGEON_ADDRESS" value="rabbitmq"/>
     <env name="PIGEON_PORT" value="5672"/>
     <env name="PIGEON_USER" value="guest"/>
     <env name="PIGEON_PASSWORD" value="guest"/>


### PR DESCRIPTION
# The Problem
When cloning this project the developer doesn't have all the dependencies to start coding.

# Solution
This feature contains a docker compose file which is going to provide the container to handle the php calls and a RabbitMQ serve to run the tests suites.

# Testing
- Checkout the branch `feature/docker-environment`;
- Inside the project run `docker-compose build --no-cache --pull`;
- After that, run `docker-compose up -d`;
- Then run `docker exec -ti pigeon sh`, that should put you inside the container;
- Inside the container run `composer install`;
- Finally, run `./vendor/bin/phpunit` and that's it;