### PR TITLE
Counting Dispatched Messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Function Pigeon::assertNothingDispatched().
+- Function Pigeon::assertDispatchedCount(int $count).
 ## [v2.1.0]
 ### Added
 - Laravel 9 support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,22 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Function Pigeon::assertNothingDispatched().
 - Function Pigeon::assertDispatchedCount(int $count).
+
 ## [v2.1.0]
 ### Added
 - Laravel 9 support
 - php 8.1 support
+
 ## [v2.0.0]
 ### Fixed
 - Properties on publish method
 - Reconnect when missed heart beat
+
 ### Added
 - Laravel 8 support
 - Added `Pigeon::assertNotDispatched()` method to Fake driver
+
 ### Changed
 - Change `emmit` method name to `dispatch`
 - Change `assertEmitted` method name to `assertDispatched`
 - Property `Convenia\Pigeon\Resolver\Resolver::message` is public now
 - Method `Convenia\Pigeon\Publisher\PublisherContract::publish()` now have the second param as a properties array
+
 ### Removed
 - Methods `Pigeon::rpc`, `Convenia\Pigeon\Resolver::response`, `Pigeon::assertRpc`, `Pigeon::rpcPushed`, `Pigeon::assertCallbackReturn`
 - Drop PHP 7.2 support
@@ -38,8 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added hability to test for timeout on consumers
 - Added hability to test for comsmer multiplicit
+
 ### Changed
 - Catch `Throwble` instead of `Exception` on default fallback
+
 ### Fixed
 - Fixed support for Laravel 6
 - Fixed facade `dispatch` signature
@@ -51,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v1.4.0]
 ### Added
 - Added hability to send to default exchange when the exchange name is empty in `exchange()` method
+
 ### Fixed
 - Fixed use of empty string on exchange to use default AMQP queue
 
@@ -63,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `on-failure` config to ack, reject or throw exception
 - Added `Pigeon::headers([])` and config `headers` key
 - Added possibility to use callable on headers config
+
 ### Fixed
 - Fixed failing when not set fallback and throw exception
 - Fixed wrong `MessageProcessorTest` tests
@@ -71,9 +80,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added bugs test suite
 - Added null driver throw `Convenia\Pigeon\Exceptions\Driver\NullDriverException` exception
+
 ### Fixed
 - Fix `No free channel id` message when emit large amount of events
 - Fix env example
+
 ### Changed
 - Change default driver to `rabbit`
 
@@ -85,6 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `application_headers` to `Pigeon::dispatch` as last parameter
 - Add configurable precondition catch on queue creation
+
 ### Fixed
 - Auto declare exchange with `routing`
 - Fix `application_headers` to `AMQPTable`
@@ -103,16 +115,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added dead letter exchange to queue/exchange declare
 - Added laravel auto discovery
 - Added config as publishable using `pigeon.config`
+
 ### Change
 - Default timeout from 5 to 0
+
 ### Fixed
 - Fix acknowledge with fake
+
 ### Removed
 - Remove `$properties` from `PublisherContract::publish()`, `PublisherContract::rpc()`
 
 ## [v1.0.0-alpha-1]
 ### Fixed
 - Fixed `getDefaultDriver` return from config
+
 ### Change
 - Change event listen wildcard from `*` to `#`
 - Change event exchange type from `direct` to `topic`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -59,3 +59,39 @@ Pigeon::dispatchConsumer(
     ['mocked' => 'message'] // mocked incoming message
 );
 ``` 
+
+There is a way to only verify the expected quatity of messages sent.
+
+If you want to assert the exact number of messages, use `assertDispatchCount`.
+```php
+<?php
+
+use Convenia\Pigeon\Facade\Pigeon;
+
+Pigeon::fake();
+
+Pigeon::emmit('my-queue', [
+    'some-data' => 123,
+]);
+
+Pigeon::emmit('another-great-queue', [
+    'some-data' => 123,
+]);
+
+Pigeon::assertDispatchCount(2); // Returns true
+```
+
+If you want to only check if nothing was sent, use `assertNothingDispatched`.
+```php
+<?php
+
+use Convenia\Pigeon\Facade\Pigeon;
+
+Pigeon::fake();
+
+Pigeon::emmit('my-queue', [
+    'some-data' => 123,
+]);
+
+Pigeon::assertNothingDispatched(); // Returns false
+```

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -70,11 +70,11 @@ use Convenia\Pigeon\Facade\Pigeon;
 
 Pigeon::fake();
 
-Pigeon::emmit('my-queue', [
+Pigeon::dispatch('my-queue', [
     'some-data' => 123,
 ]);
 
-Pigeon::emmit('another-great-queue', [
+Pigeon::dispatch('another-great-queue', [
     'some-data' => 123,
 ]);
 
@@ -89,7 +89,7 @@ use Convenia\Pigeon\Facade\Pigeon;
 
 Pigeon::fake();
 
-Pigeon::emmit('my-queue', [
+Pigeon::dispatch('my-queue', [
     'some-data' => 123,
 ]);
 

--- a/src/Support/Testing/PigeonFake.php
+++ b/src/Support/Testing/PigeonFake.php
@@ -107,6 +107,27 @@ class PigeonFake extends PigeonManager implements DriverContract
         );
     }
 
+    /**
+     * Checks if none message was dispatched.
+     *
+     * @return void
+     */
+    public function assertNothingDispatched()
+    {
+        $this->assertDispatchCount(0);
+    }
+
+    /**
+     * Checks if the expected quantity of messages was dispatched.
+     *
+     * @param  int  $count
+     * @return void
+     */
+    public function assertDispatchCount(int $count)
+    {
+        PHPUnit::assertCount($count, $this->events);
+    }
+
     public function pushed(string $routing, array $message, $callback = null)
     {
         $callback = $callback ?: function ($publisher) use ($routing, $message) {

--- a/tests/Unit/PigeonFakeTest.php
+++ b/tests/Unit/PigeonFakeTest.php
@@ -7,11 +7,15 @@ use Convenia\Pigeon\Facade\Pigeon;
 use Convenia\Pigeon\Publisher\Publisher;
 use Convenia\Pigeon\Resolver\ResolverContract;
 use Convenia\Pigeon\Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
 use PHPUnit\Framework\Constraint\ExceptionMessage;
 use PHPUnit\Framework\ExpectationFailedException;
 
 class PigeonFakeTest extends TestCase
 {
+    use WithFaker;
+
+    /** @var \Convenia\Pigeon\Support\Testing\PigeonFake */
     protected $fake;
 
     protected function setUp(): void
@@ -437,5 +441,36 @@ class PigeonFakeTest extends TestCase
         ];
 
         $this->fake->assertNotDispatched($category, $data);
+    }
+
+    public function test_it_asserts_nothing_dispatched()
+    {
+        $this->fake->assertNothingDispatched();
+
+        $this->fake->dispatch('some.dummy.queue', ['dummy-field' => 123]);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that actual size 1 matches expected size 0.');
+
+        $this->fake->assertNothingDispatched();
+    }
+
+    public function test_if_asserts_the_count_of_messages()
+    {
+        $howMany = 22;
+
+        for ($i = $howMany; $i > 0; $i--) {
+            $this->fake->dispatch(
+                implode('.', $this->faker->words()),
+                ['some-dummy-field' => $this->faker->sentence()]
+            );
+        }
+
+        $this->fake->assertDispatchCount($howMany);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that actual size 22 matches expected size 10.');
+
+        $this->fake->assertDispatchCount(10);
     }
 }


### PR DESCRIPTION
# The Problem
Sometimes, we only want to make sure some message wasen't dispatched, or we lack of some fields that are created in the code execution, but we only want to make sure that we got something dispatched or not.

# The Solution
Here's two simple assertions that can do that simply by counting the messages dispatched in the code execution.

# Testing
- Add this package to some project.
- Create a test where some or none messages it's being dispatched.
- Make you assertions using the new functions.